### PR TITLE
Imporve Selenium waiting algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ services:
   - docker
 
 script:
-  - docker-compose build --no-cache
-  - docker-compose up --abort-on-container-exit jcat-on-firefox
+  - docker-compose up --build --abort-on-container-exit jcat-on-firefox

--- a/jcat.sh
+++ b/jcat.sh
@@ -10,7 +10,7 @@ wait_selenium() {
   counter=0
   while true; do
     counter=$((counter+1))
-    ( wget --quiet --output-document - ${SELENIUM_URL}/status | grep '"ready":true') ||
+    ( wget --quiet --output-document - ${SELENIUM_URL}/status | grep 'true,') ||
       {
         if test ${counter} -gt 30 ; then
           echo "Operation timed out!" >&2


### PR DESCRIPTION
When `wget` calls `/status` endpoint, it may receive the output in
compact or verbose format depending on the version of Selenium HUB.
That's why wait logic looks for `true,` for determining if Grid is ready
or not.

Compact:
```json
{ "value": { "ready": true, "message": "Selenium Grid ready.", "nodes":
[ { "id": "dd30b90a-10c1-4adf-ade2-18f15e96ac5f", "uri":
"http:\u002f\u002f172.27.0.3:5555", "maxSessions": 4, "stereotypes": [ {
"capabilities": { "browserName": "firefox" }, "count": 4 } ],
"sessions": [ ] } ] } }
```

Verbose:
```json
{
  "value": {
    "ready": true,
    "message": "Selenium Grid ready.",
    "nodes": [
      {
        "id": "dd30b90a-10c1-4adf-ade2-18f15e96ac5f",
        "uri": "http:\u002f\u002f172.27.0.3:5555",
        "maxSessions": 4,
        "stereotypes": [
          {
            "capabilities": {
              "browserName": "firefox"
            },
            "count": 4
          }
        ],
        "sessions": [
        ]
      }
    ]
  }
}
```